### PR TITLE
(WIP) Feature/append and use

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -205,12 +205,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 	/**
 	 * Assign posts associated with a WordPress user to a co-author
-	 * Only apply the changes if there aren't yet co-authors associated with the post
 	 *
 	 * @since 3.0
 	 *
 	 * @subcommand assign-user-to-coauthor
-	 * @synopsis --user_login=<user-login> --user_id=<user-id> --coauthor=<coauthor>
+	 * @synopsis [--user_login=<user-login>] [--user_id=<user-id>] --coauthor=<coauthor> [--append_coauthors]
 	 */
 	public function assign_user_to_coauthor( $args, $assoc_args ) {
 		global $coauthors_plus, $wpdb;
@@ -219,6 +218,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'user_login'        => NULL,
 				'user_id'           => NULL,
 				'coauthor'          => '',
+				'append_coauthors'  => false,
 			);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
@@ -245,7 +245,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
 			$coauthors = cap_get_coauthor_terms_for_post( $post_id );
-			if ( ! empty( $coauthors ) ) {
+			if ( ! empty( $coauthors ) && ! $assoc_args['append_coauthors'] ) {
 				WP_CLI::line( sprintf(
 					__( 'Skipping - Post #%d already has co-authors assigned: %s', 'co-authors-plus' ),
 					$post_id,
@@ -254,7 +254,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				continue;
 			}
 
-			$coauthors_plus->add_coauthors( $post_id, array( $coauthor->user_login ) );
+			$coauthors_plus->add_coauthors( $post_id, array( $coauthor->user_login ), true );
 			WP_CLI::line( sprintf( __( "Updating - Adding %s's byline to post #%d", 'co-authors-plus' ), $coauthor->user_login, $post_id ) );
 			$affected++;
 			if ( $affected && 0 === $affected % 100 ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -225,7 +225,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$user_id = $assoc_args['user_id'];
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
-			$user_id = $user->ID;
+			if ($user) {
+				$user_id = $user->ID;
+			}
 		}
 
 		$coauthor = $coauthors_plus->get_coauthor_by( 'login', $assoc_args['coauthor'] );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -222,7 +222,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$user_id = $assoc_args['user_login'];
+		$user_id = $assoc_args['user_id'];
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
 			$user_id = $user->ID;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -222,7 +222,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$user_id = $assoc_args['user_id'];
+		$user_id = intval($assoc_args['user_id']);
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
 			if ($user) {


### PR DESCRIPTION
Amends the WP Cli `assign-user-to-coauthor` command so that:

a) A user whose posts should be assigned to a coauthor can be specified by user ID, rather than user login. This allows for the command to be run even after the user has been deleted, if posts remain assigned to their user ID.
b) The `--append_coauthors` option can be so that the coauthor will be added even if a coauthor is already assigned to the affected post

(N.B. this PR doesn't necessarily need to be merged, I've just opened it for ease of reviewing these changes,  hence why it's marked as WIP)